### PR TITLE
[ PR ] mobile버전의 헤더 스타일을 완성한다

### DIFF
--- a/web/src/components/common/Header/Header.tsx
+++ b/web/src/components/common/Header/Header.tsx
@@ -10,6 +10,12 @@ const Header: React.FC = () => {
         <S.HeaderTitle>
           <S.HeaderTitleImage />
         </S.HeaderTitle>
+        <S.HeaderMobileCategory>
+          <S.HeaderMobileCategoryImage />
+        </S.HeaderMobileCategory>
+        <S.HeaderMobileSearch>
+          <S.HeaderMobileSearchImage />
+        </S.HeaderMobileSearch>
         <S.HeaderLeftMenuList>
           <S.CategoryList>
             <a href="/">카테고리</a>

--- a/web/src/components/common/Header/style.tsx
+++ b/web/src/components/common/Header/style.tsx
@@ -23,7 +23,7 @@ const S = {
       width: 1080px;
     }
     @media (max-width: 769px) {
-      background-color: blue;
+      /* background-color: blue; */
     }
   `,
   HeaderTitle: styled.h1`
@@ -60,6 +60,9 @@ const S = {
     }
   `,
   SearchBar: styled.div`
+    @media (max-width: 769px) {
+      display: none;
+    }
     position: absolute;
     right: 135px;
     top: 13px;
@@ -164,6 +167,9 @@ const S = {
     }
   `,
   HeaderMyPage: styled.a`
+    @media (max-width: 769px) {
+      display: none;
+    }
     position: absolute;
     right: 94px;
     top: 0px;
@@ -186,26 +192,76 @@ const S = {
     @media (min-width: 769px) {
     }
   `,
-  HeaderLeftMenuList: styled.ul`
-    display: flex;
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 66px;
-    -webkit-box-align: center;
-    align-items: center;
-    li {
-      position: relative;
-      height: 66px;
-      font-size: 15px;
-      color: rgb(30,30,30);
-      margin-right: 24px;
+  HeaderMobileCategory: styled.button`
+    @media (min-width: 769px) {
+      display: none;
     }
-    li > a {
+    @media (max-width: 769px) {
+      display: block;
+      position: absolute;
+      top: 0px;
+      left: 0px;
+      height: 60px;
+      padding: 0px 10px;
+      outline: none;
+    }
+  `,
+  HeaderMobileCategoryImage: styled.span`
+    background-image: url(https://t1.kakaocdn.net/friends/kfo-common/mo/m640/img_gnb_181002.png);
+    background-size: 200px 95px;
+    display: block;
+    width: 19px;
+    height: 14px;
+    background-position: -180px 0px;
+  `,
+  HeaderMobileSearch: styled.button`
+    @media (min-width: 769px) {
+      display: none;
+    }
+    @media (max-width: 769px) {
+      display: block;
+      position: absolute;
+      left: 39px;
+      right: auto;
+      top: 0px;
+      width: 32px;
+      overflow: hidden;
+      padding: 22px 8px;
+    }
+  `,
+  HeaderMobileSearchImage: styled.span`
+    display: block;
+    width: 16px;
+    height: 16px;
+    background-image: url(https://t1.kakaocdn.net/friends/kfo-common/mo/m640/img_gnb_181002.png);
+    background-size: 200px 95px;
+    background-position: -126px -42px;
+  `,
+  HeaderLeftMenuList: styled.ul`
+    @media (max-width: 769px) {
+      display: none;
+    }
+    @media (min-width: 769px) {
       display: flex;
+      position: absolute;
+      top: 0px;
+      left: 0px;
+      height: 66px;
       -webkit-box-align: center;
       align-items: center;
-      height: 66px;
+      li {
+        position: relative;
+        height: 66px;
+        font-size: 15px;
+        color: rgb(30,30,30);
+        margin-right: 24px;
+      }
+      li > a {
+        display: flex;
+        -webkit-box-align: center;
+        align-items: center;
+        height: 66px;
+      }
     }
   `,
   CategoryList: styled.li`

--- a/web/src/styles/global.ts
+++ b/web/src/styles/global.ts
@@ -6,7 +6,7 @@ const GlobalStyle = createGlobalStyle`
   font-family: 'Apple SD Gothic Neo', AppleSDGothicNeo, 'Malgun Gothic', '맑은 고딕', sans-serif;
   letter-spacing: -0.2px;
   font-size: 14px;
-  line-height: 1.5;
+  /* line-height: 1.5; */
   color: #1e1e1e;
   button, input {
     font-family: "Apple SD Gothic Neo", AppleSDGothicNeo, "Malgun Gothic", "맑은 고딕", sans-serif;


### PR DESCRIPTION
#mobile버전의 헤더 스타일을 완성한다 (#12)

## 해당 이슈 📎

- [Epic#7] mobile버전의 헤더 스타일을 완성한다 (#12)

## 변경 사항 🛠

```
- 모바일 버전의 헤더를 구현
- css가 복잡해 지고 있기 때문에, @media쿼리를 재사용 가능한 방법을 찾아봐야한다
- 헤더를 구현하면서 모바일과 PC버전의 공통되는 기능을 재사용 가능할 수 있도록 설계를 해야 한다
```

## 테스트 ✨

> 없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음
