### PR TITLE
[ PR ] 재사용 가능한 popover를 구현한다

### DIFF
--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -1,0 +1,2 @@
+# ignored webpack.config.js
+config/*.js

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -1,4 +1,20 @@
 {
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": true
+  },
+  "extends": [
+    "airbnb-typescript",
+    "airbnb/hooks",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2018,
@@ -8,25 +24,8 @@
     },
     "project": "./tsconfig.json"
   },
-  "extends": [
-    "airbnb-typescript",
-    "airbnb/hooks",
-    "plugin:@typescript-eslint/eslint-recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking"
-  ],
-  "plugins": ["react"],
-  "env": {
-    "es6": true,
-    "node": true,
-    "browser": true
-  },
-  "globals": {
-    "Atomics": "readonly",
-    "SharedArrayBuffer": "readonly"
-  },
+  "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    // "@typescript-eslint/no-var-requires": "off",
     "react/prop-types": "off",
     "import/prefer-default-export": "off"
   },

--- a/web/src/components/common/Header/Customer/Customer.tsx
+++ b/web/src/components/common/Header/Customer/Customer.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const Customer: React.FC = () => (
+  <>Customer Popover</>
+);
+
+export default Customer;

--- a/web/src/components/common/Header/Customer/index.ts
+++ b/web/src/components/common/Header/Customer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Customer';

--- a/web/src/components/common/Header/Customer/style.tsx
+++ b/web/src/components/common/Header/Customer/style.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const S = {
+
+};
+
+export default S;

--- a/web/src/components/common/Header/GoodsCategory/GoodsCategory.tsx
+++ b/web/src/components/common/Header/GoodsCategory/GoodsCategory.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const GoodsCategory: React.FC = () => (
+  <>Goods Category</>
+);
+
+export default GoodsCategory;

--- a/web/src/components/common/Header/GoodsCategory/index.ts
+++ b/web/src/components/common/Header/GoodsCategory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GoodsCategory';

--- a/web/src/components/common/Header/GoodsCategory/style.tsx
+++ b/web/src/components/common/Header/GoodsCategory/style.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const S = {
+
+};
+
+export default S;

--- a/web/src/components/common/Header/index.ts
+++ b/web/src/components/common/Header/index.ts
@@ -1,1 +1,4 @@
+// export { default as Header } from './Header';
+// export { default as Customer } from './Customer';
+// export { default as GoodsCategory } from './GoodsCategory';
 export { default } from './Header';

--- a/web/src/components/common/Popover/Popover.tsx
+++ b/web/src/components/common/Popover/Popover.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import Customer from '../Header/Customer';
+import GoodsCategory from '../Header/GoodsCategory';
+import S from './style';
+
+interface PopoverProps {
+  mode: string;
+}
+
+const Popover: React.FC<PopoverProps> = ({ mode }) => (
+  <>
+    <S.PopoverWrapper>
+      {mode === 'customer' ? <Customer /> : <GoodsCategory />}
+    </S.PopoverWrapper>
+  </>
+);
+
+export default Popover;

--- a/web/src/components/common/Popover/index.ts
+++ b/web/src/components/common/Popover/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Popover';

--- a/web/src/components/common/Popover/style.tsx
+++ b/web/src/components/common/Popover/style.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const S = {
+  PopoverWrapper: styled.div`
+    position: absolute;
+    top: 65px;
+    left: -32px;
+    background-color: rgb(255, 255, 255);
+    display: flex;
+    box-shadow: rgba(0, 0, 0, 0.08) 0px 12px 20px 0px;
+    z-index: 999999;
+    padding: 32px 0px;
+    border-radius: 3.2px;
+    animation: 0.5s ease-in-out 0s 1 normal none running fadeIn;
+  `,
+};
+
+export default S;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -2,7 +2,4 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from './App';
 
-ReactDOM.render(
-  <App />,
-  document.querySelector('#app'),
-);
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/web/src/pages/Main/Main.tsx
+++ b/web/src/pages/Main/Main.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import Popover from '@/components/common/Popover';
 
 const Main: React.FC = () => {
-  const a = 3;
+  const category = 'category';
 
   return (
     <>
+      <Popover mode={category} />
       Main Page
     </>
   );

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "baseUrl": ".",
     "typeRoots": [
       "./node_modules/@types",
       "./src/@types"
@@ -20,6 +19,7 @@
       "es2020",
       "dom"
     ],
+    "baseUrl": ".",
     "allowJs": true,
     "noImplicitAny": false,
     "removeComments": true,
@@ -27,9 +27,6 @@
     "sourceMap": true,
     "jsx": "react"
   },
-  "include": ["src"],
-  "exclude": [
-    "node_modules",
-    "config"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "config"]
 }


### PR DESCRIPTION
# 재사용 가능한 popover를 구현한다 (#14)

## 해당 이슈 📎

- [Epic#9] 재사용 가능한 popover를 구현한다 (#14)

## 변경 사항 🛠

```
- 공통으로 쓰이기 때문에 common에 popover 컴포넌트 생성 및 스타일 구현
- 헤더에 쓰일 category와 customer 두개의 popover를 위해 각 컴포넌트 생성
- 추가로 eslintignore를 통해 webpack의 eslinting 제거
```

## 테스트 ✨

> 없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음
